### PR TITLE
Add ability to transform migrations in Migratefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,33 @@ migrate all
 * **ext** -- The extension for your migration files.  Defaults to `coffee`.
 * **template** -- The template used when generating migrations.
 * **context** -- Values provided as part of `this` within all migration functions (`up`, `down`, and `test`)
+* **transform** -- A function that allows you to transform migrations before they are run.
 
 before/after callbacks are called in this order: [ beforeTest, before, after, afterTest ]
+
+## Migrations that take promises
+
+One way to accomplish this is with a `Migratefile` that looks like this, which
+will allow you to define migrations with `upPromise`, `downPromise`, and
+`testPromise` functions:
+
+```javascript
+var Promise = require 'bluebird';
+
+module.exports = {
+  transform: function(migration) {
+    ['up', 'down', 'test'].forEach(function(fn) {
+      var promiseVersion = migration[fn + "Promise"];
+      if (promiseVersion) {
+        migration[fn] = function(done) {
+          return Promise.resolve(promiseVersion()).nodeify(done);
+        };
+      }
+    });
+    return migration;
+  }
+}
+```
 
 ## Contributing
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -16,7 +16,7 @@ module.exports = (config, argv) ->
 
   # opts: ext, path, template, mongo
   trimmedConfig = {}
-  trimmedConfig[k] = v for k, v of config when k in ['ext', 'path', 'template', 'mongo', 'context']
+  trimmedConfig[k] = v for k, v of config when k in ['ext', 'path', 'template', 'mongo', 'context', 'transform']
   migrate = new CustomMigrate trimmedConfig
 
   die = (message) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -58,6 +58,10 @@ class Migrate
     migration = require pathName
     assign(migration, {name: migrationName})
     assign(migration, @opts.context)
+
+    if @opts.transform?
+      migration = @opts.transform migration
+
     migration
 
   exists: (name, done) ->

--- a/test/node_migrate_mongo.test.coffee
+++ b/test/node_migrate_mongo.test.coffee
@@ -86,6 +86,23 @@ describe 'node-migrate-mongo', ->
       it 'has context', ->
         expect(migration.foo).to.equal 'bar'
 
+    describe 'given config including a transform', ->
+      beforeEach 'set up Migrate with a transform', ->
+        @migrate2 = new Migrate
+          path: path.join(__dirname, 'test-migrations')
+          model: StubMigrationVersion
+          transform: (migration) ->
+            migration.herp = 'derp'
+            migration
+        sinon.stub @migrate2, 'log'
+
+      afterEach ->
+        @migrate2.log.restore()
+
+      it 'calls the transform', ->
+        migration = @migrate2.get 'migration'
+        expect(migration.herp).to.equal 'derp'
+
   describe '.exists', ->
     before fibrous ->
       sinon.stub StubMigrationVersion, 'count', ({name}, cb) ->


### PR DESCRIPTION
This opens up a lot of possibilities, including the ability to write
migrations that return promises instead of callbacks, for example.

(See README for more on this.)