### PR TITLE
Extract migration logic from data storage logic

### DIFF
--- a/src/store.coffee
+++ b/src/store.coffee
@@ -1,0 +1,50 @@
+mongoose = require 'mongoose'
+
+module.exports = class MongoStore
+  constructor: (@opts={}) ->
+    @_model = @opts.model
+    @opts.template ?= """
+      module.exports =
+        requiresDowntime: FIXME # true or false
+
+        up: (done) ->
+          done()
+
+        down: (done) ->
+          throw new Error('irreversible migration')
+
+        test: (done) ->
+          console.log 'copying development to test'
+          require('child_process').exec "mongo test --eval \\"db.dropDatabase(); db.copyDatabase('development', 'test'); print('copied')\\"", ->
+            done()
+    """
+
+  model: ->
+    @_model ?= do =>
+      @opts.mongo = @opts.mongo() if typeof @opts.mongo is 'function'
+      connection = mongoose.createConnection @opts.mongo
+
+      schema = new mongoose.Schema
+        name:  type: String, index: true, unique: true, required: true
+        createdAt:  type: Date, default: Date.now
+
+      connection.model 'MigrationVersion', schema, 'migration_versions'
+
+  exists: (name, done) ->
+    @model().count {name}, (err, count) ->
+      return done(err) if err
+      done(null, count > 0)
+
+  save: (name, done) ->
+    @model().create {name}, done
+
+  remove: (name, done) ->
+    @model().remove({name}, done)
+
+  getMostRecent: (done) ->
+    @model().findOne {}, {name: 1}, {sort: 'name': -1}, (err, version) =>
+      return done(err) if err
+      return done(null, version?.name ? null)
+
+  getAll: (done) ->
+    @model().distinct('name', done)

--- a/test/node_migrate_mongo.test.coffee
+++ b/test/node_migrate_mongo.test.coffee
@@ -12,6 +12,7 @@ class StubMigrationVersion
   @create: ->
   @distinct: ->
   @count: ->
+  @remove: ->
 
 describe 'node-migrate-mongo', ->
   migrate = null
@@ -237,11 +238,13 @@ describe 'node-migrate-mongo', ->
         name: 'migration'
         remove: sinon.stub().yields()
       sinon.stub(StubMigrationVersion, 'findOne').yields null, version
+      sinon.stub(StubMigrationVersion, 'remove').yields null, 1
 
       migrate.sync.down()
 
     after ->
       StubMigrationVersion.findOne.restore()
+      StubMigrationVersion.remove.restore()
       migrate.get.restore()
 
     it 'calls down on the migration', fibrous ->
@@ -251,7 +254,7 @@ describe 'node-migrate-mongo', ->
       expect(migration.down).to.have.been.calledOn sinon.match foo: 'bar'
 
     it 'removes version', fibrous ->
-      expect(version.remove).to.have.been.calledOnce
+      expect(StubMigrationVersion.remove).to.have.been.calledWith sinon.match name: 'migration'
 
   describe '.pending', ->
     {pending} = {}


### PR DESCRIPTION
It was annoying me that this module and [node-migrate-redis](https://github.com/goodeggs/node-migrate-redis) didn't share code, even though they do pretty much exactly the same thing. The code was just copy-pasted from one module to the other! And this module has been since updated. Hence, the plan:

1. Pull all the shared code out into its own module, I'm thinking [data-migrate](https://www.npmjs.com/package/data-migrate) or something
2. Require that module in this one and also in node-migrate-redis
3. ???
4. Profit (from DRY-er code)