### PR TITLE
Upgrade interpret & liftoff to support babel in Migratefiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+sudo: required
+dist: trusty
 language: node_js
 node_js:
-  - '0.10'
+  - '6'
+  - '8'
+env:
+  global:
+    - NODE_ENV=test

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "async": "^0.9.2",
     "fs-extra": "^0.13.0",
-    "interpret": "^0.3.10",
-    "liftoff": "^2.0.0",
+    "interpret": "^1.0.4",
+    "liftoff": "^2.3.0",
     "lodash.assign": "^3.2.0",
     "lodash.isfunction": "^3.0.6",
     "minimist": "^1.1.0",


### PR DESCRIPTION
Call your Migratefile "Migratefile.babel.js" and it just works. No more [weird gross ES5 Migratefiles](https://github.com/goodeggs/pick-api/blob/902d24577c06069b7b41ed0f49e31a8e78e9bee4/Migratefile.js).

cc @bobzoller @jason-h-hu