### PR TITLE
feat: support passing MongoDB client connection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# CHANGELOG
+
+## v3.0.0
+
+### Breaking changes
+
+Previously, the Migratefile `mongo` option supported either a MongoDB connection URL string,
+or a function that returned such a string.
+```js
+// NO LONGER SUPPORTED
+{
+  mongo: 'mongodb://localhost:27017/foo',
+}
+```
+
+```js
+// NO LONGER SUPPORTED
+{
+  mongo: () => 'mongodb://localhost:27017/foo',
+}
+```
+
+Now, this option only supports an object with a required `url` string and an optional `options`
+object:
+```js
+// NEW SIGNATURE
+{
+  mongo: {
+    url: 'mongodb://localhost:27017/foo',
+  },
+}
+```
+
+```js
+// NEW SIGNATURE, with options
+{
+  mongo: {
+    url: 'mongodb://localhost:27017/foo',
+    options: {
+      // any MongoDB client driver connection options, e.g.:
+      connectTimeoutMS: 30000,
+    },
+  },
+}
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Your Migratefile file can be any JavaScript variant recognized by [interpret](ht
 * **before** -- An async function called before running a command.  Useful for connecting your app to its database.
 * **after** -- An async function called after running a command.
 * **afterTest** -- An async function called after running a migration test.
-* **mongo** -- A string or function that returns a mongo connection string.
+* **mongo.url** -- (required) A MongoDB connection string.
+* **mongo.options** -- An options object passed to the MongoDB client connection.
 * **model** -- A reference to your custom `MigrationVersion` model.
 * **path** -- The place to store your migration files.  Defaults to `migrations`.
 * **ext** -- The extension for your migration files.  Defaults to `coffee`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-migrate-mongo",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Migrations for MongoDB",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/src/store.coffee
+++ b/src/store.coffee
@@ -21,8 +21,12 @@ module.exports = class MongoStore
 
   model: ->
     @_model ?= do =>
-      @opts.mongo = @opts.mongo() if typeof @opts.mongo is 'function'
-      connection = mongoose.createConnection @opts.mongo
+      if typeof @opts.mongo isnt 'object'
+        throw new Error('`mongo` Migratefile option must now be an object {url, options}')
+      {url, options} = @opts.mongo
+      if not url?
+        throw new Error('`mongo.url` Migratefile option is required')
+      connection = mongoose.createConnection(url, options)
 
       schema = new mongoose.Schema
         name:  type: String, index: true, unique: true, required: true


### PR DESCRIPTION
This library is printing all sorts of mongoose warnings to the console. We can't fix it in our apps because the library currently provides no way to thread mongoose/mongo connection options.

This resolves that.

We decided to make this a breaking change, since there's no particular reason to support the current shape, the breaking change is very easy to fix, and at least at Good Eggs we'll only have a couple places to update.

:pear: with @risharma